### PR TITLE
remove label "instance" from Prometheus metrics

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,24 +35,30 @@ Metrics are provided for current connected peers and for well known peers define
 
 - `quorum_peers`
   - Description: Quorum peers by enode
-  - Labels: instance, instance_name, enode, enode_short, name
-  - Values: 0=not connected (but defined in config), 1=connected
+  - Labels: instance_name, enode, enode_short, name
+  - Values:
+    - `0` - not connected (but defined in config)
+    - `1` - connected
 - `quorum_peers_network_direction`
   - Description: Quorum peers network direction by enode
-  - Labels: instance, instance_name, enode, enode_short, name
-  - Values: 0=not connected (but defined in config), 1=inbound traffix, 2=outbound traffic
+  - Labels: instance_name, enode, enode_short, name
+  - Values:
+    - `0` - not connected (but defined in config)
+    - `1` - inbound traffix
+    - `2` - outbound traffic
 - `quorum_peers_head_block`
   - Description: Quorum peers head block by enode and protocol eth or istanbul
-  - Labels: instance, instance_name, enode, enode_short, name, protocol
+  - Labels: instance_name, enode, enode_short, name, protocol
   - Values: The latest block of the connected peer
 - `quorum_tcp_egress_connectivity`:
   - Description: Quorum TCP egress connectivity to other nodes by enode.
-  - Labels: instance, instance_name, enode, enode_short, name
-  - Values: 0=no connectivity/an outbound connection cannot be established, 1=connection can be established
+  - Labels: instance_name, enode, enode_short, name
+  - Values:
+    - `0` - no connectivity/an outbound connection cannot be established
+    - `1` - connection can be established
 
 ### Metric Labels
 
-- `instance` - The local IP address of the Quorum node followed by ':9545', e.g. `10.2.3.4:9545`
 - `instance_name` - The host name of the Quorum node taken from RPC_URL
 - `enode` - The 128 hex chars enode of the peer
 - `enode_short` - The first 20 chars of the 128 hex chars enode

--- a/source/utils/kube_exec_metrics_collector.py
+++ b/source/utils/kube_exec_metrics_collector.py
@@ -33,12 +33,12 @@ class KubeExecMetricsCollector(Collector):
         """
         return self._current_metrics
 
-    def _lookup_pod_name_and_ip(self) -> tuple:
-        """Looks up for the pod and its ip address by configuration settings,
+    def _lookup_pod_name(self) -> str:
+        """Looks up for the pod by configuration settings,
             e.g. by  deployment name and namespace.
 
         Returns:
-            tuple: pod name and ip address
+            str: pod name
         """
         apps_v1 = apps_v1_api.AppsV1Api()
         core_v1 = core_v1_api.CoreV1Api()
@@ -64,7 +64,8 @@ class KubeExecMetricsCollector(Collector):
 
         # Get pods by selector
         pod_list = core_v1.list_namespaced_pod(namespace=self._config.namespace,
-                                               label_selector=label_selector_string, watch=False, _request_timeout=(1, 2))
+                                               label_selector=label_selector_string,
+                                               watch=False, _request_timeout=(1, 2))
 
         if pod_list is None or len(pod_list.items) == 0:
             logging.warning("%s >> No pods found - label_selector=%s, namespace=%s",
@@ -79,7 +80,8 @@ class KubeExecMetricsCollector(Collector):
                              type(self).__name__, each_pod.metadata.name)
             return (None, None)
 
-        return (pod_list.items[0].metadata.name, pod_list.items[0].status.pod_ip)
+        #return (pod_list.items[0].metadata.name, pod_list.items[0].status.pod_ip)
+        return pod_list.items[0].metadata.name
 
     def _kube_exec_check_connectivity(self, pod_name: str, peer: PeerConfig):
         """Checks the connectivity from within the pod to the peer
@@ -114,26 +116,25 @@ class KubeExecMetricsCollector(Collector):
 
         return connection_successful
 
-    def create_current_metrics(self, instance: str, instance_name: str, pod_name: str):
+    def create_current_metrics(self, instance_name: str, pod_name: str):
         """Creates the current metrics
 
         Args:
-            instance (str): The instance name
             instance_name (str): A pretty instance name
             pod_name (str): The pod name
         """
-        logging.info("%s >> Creating metrics for %s peers - instance=%s, instance_name=%s, pod_name=%s, namespace=%s",
+        logging.info("%s >> Creating metrics for %s peers - instance_name=%s, pod_name=%s, namespace=%s",
                      type(self).__name__, len(self._config.peers.keys()),
-                     instance, instance_name, pod_name, self._config.namespace)
+                     instance_name, pod_name, self._config.namespace)
 
         metrics = GaugeMetricFamily('quorum_tcp_egress_connectivity',
                                     'Quorum TCP egress connectivity to other nodes by enode. (0) for no connectivity, (1) for connectivity can be established',
-                                    labels=['instance', 'instance_name', 'enode', 'enode_short', 'name'])
+                                    labels=['instance_name', 'enode', 'enode_short', 'name'])
 
         for each_config_peer in self._config.peers.values():
             connection_successful = self._kube_exec_check_connectivity(
                 pod_name=pod_name, peer=each_config_peer)
-            metrics.add_metric([instance, instance_name, each_config_peer.enode,
+            metrics.add_metric([instance_name, each_config_peer.enode,
                                 each_config_peer.enode[0:20], each_config_peer.name],
                                1 if connection_successful else 0)
 
@@ -150,12 +151,10 @@ class KubeExecMetricsCollector(Collector):
         # Get DNS name and use it as "pretty" instance name
         instance_name = self._helper.get_host_name(url=self._config.rpc_url)
         # Retrieve pods name and ip
-        pod_name, pod_ip = self._lookup_pod_name_and_ip()
+        pod_name = self._lookup_pod_name()
 
-        if pod_name is not None and pod_ip is not None:
-            # add same port as Quorum Node default metrics also do
-            instance = f"{pod_ip}:9545"
-            self.create_current_metrics(instance, instance_name, pod_name)
+        if pod_name is not None:
+            self.create_current_metrics(instance_name, pod_name)
         else:
-            logging.warning("%s >> Cannot create metrics as pod_name or pod_ip is None - pod_name=%s, pod_ip=%s",
-                            type(self).__name__, pod_name, pod_ip)
+            logging.warning("%s >> Cannot create metrics as pod_name None - pod_name=%s",
+                            type(self).__name__, pod_name)


### PR DESCRIPTION
This PR removes the label "instance" from Prometheus metrics.

**Reason**

1. The value of label `instance` which is the IP address of the Quorum node cannot be determined all the time
2. The IP address is not a good label, as it may change on every deployment